### PR TITLE
Fix composer dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "spatie/laravel-ignition": "^2.0",
     "fzaninotto/faker": "^1.9.2",
     "mockery/mockery": "^1.6",
-    "nunomaduro/collision": "^9.0",
+    "nunomaduro/collision": "^7.0",
     "phpunit/phpunit": "^10.4"
 }
 ,


### PR DESCRIPTION
## Summary
- adjust `nunomaduro/collision` version requirement

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3298021083269166b30378ab3c23