### PR TITLE
Fix composer conflict with symfony console 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "spatie/laravel-ignition": "^2.0",
     "fzaninotto/faker": "^1.9.2",
     "mockery/mockery": "^1.6",
-    "nunomaduro/collision": "^7.0",
+    "nunomaduro/collision": "^8.0",
     "phpunit/phpunit": "^10.4"
 }
 ,


### PR DESCRIPTION
## Summary
- bump nunomaduro/collision to `^8.0`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f336515c883268db6530f1724fda5