### PR TITLE
Fix collision dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "spatie/laravel-ignition": "^2.0",
     "fzaninotto/faker": "^1.9.2",
     "mockery/mockery": "^1.6",
-    "nunomaduro/collision": "^9.0",
+    "nunomaduro/collision": "^7.0",
     "phpunit/phpunit": "^10.4"
   },
   "config": {


### PR DESCRIPTION
## Summary
- match dev dependency version for `nunomaduro/collision` to the version in `composer.lock`

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f35cf8fa08326840ebc7ca638115e