### PR TITLE
Update collision dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "spatie/laravel-ignition": "^2.0",
     "fzaninotto/faker": "^1.9.2",
     "mockery/mockery": "^1.6",
-    "nunomaduro/collision": "^7.0",
+    "nunomaduro/collision": "^8.0",
     "phpunit/phpunit": "^10.4"
   },
   "config": {


### PR DESCRIPTION
## Summary
- bump nunomaduro/collision requirement to `^8.0`

## Testing
- `vendor/bin/phpunit --version` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_685f36dd741083269e92527bd10ab215